### PR TITLE
Fix Rendering Links

### DIFF
--- a/Sources/Kiln/DocC/DocCLinkResolver.swift
+++ b/Sources/Kiln/DocC/DocCLinkResolver.swift
@@ -49,6 +49,16 @@ public struct DocCLinkResolver: Sendable {
         )
     }
 
+    /// Resolve an external-hyperlink reference (DocC's `link` type — how a
+    /// markdown link or autolink to an off-site URL in a doc comment is encoded)
+    /// to a link, or `nil` if the identifier isn't such a reference with a URL.
+    /// The URL is absolute, so it bypasses ``mapPath`` (which rewrites
+    /// archive-relative DocC paths, not external URLs).
+    public func resolveLink(_ identifier: String) -> ResolvedLink? {
+        guard case .link(let link)? = references[identifier], let url = link.url else { return nil }
+        return ResolvedLink(href: url, title: link.title ?? url, isSymbol: false)
+    }
+
     /// The plain title for an identifier, if any (used when a reference resolves
     /// to a topic without a URL, or an unresolvable link, so it still shows text).
     public func title(for identifier: String) -> String? {

--- a/Sources/Kiln/DocC/DocCRenderer.swift
+++ b/Sources/Kiln/DocC/DocCRenderer.swift
@@ -373,6 +373,13 @@ enum DocCInline {
             guard isActive else { return inner }
             return "<a class=\"docc-symbol-link\" href=\"\(HTMLEscaping.attribute(link.href))\">\(inner)</a>"
         }
+        // An external hyperlink (DocC `link` reference): a plain anchor to the
+        // absolute URL, matching the inline `.link` markdown case.
+        if let external = resolver.resolveLink(identifier) {
+            let inner = text(default: external.title)
+            guard isActive else { return inner }
+            return "<a href=\"\(HTMLEscaping.attribute(external.href))\">\(inner)</a>"
+        }
         // Not a linkable topic (unresolvable, or topic without a URL): render text.
         return text(default: resolver.title(for: identifier) ?? "")
     }

--- a/Sources/Kiln/Kiln.docc/Kiln.md
+++ b/Sources/Kiln/Kiln.docc/Kiln.md
@@ -1,0 +1,12 @@
+# ``Kiln``
+
+Type-safe documentation sites, built in Swift.
+
+## Overview
+
+Kiln turns a Swift-defined ``KilnSite`` and a directory of markdown into a fast,
+modern static website — with versioning, localisation, client-side search, and
+API reference rendered from DocC.
+
+For a large, multi-package DocC site built with Kiln, see the
+[Vapor API docs](https://api.vapor.codes).

--- a/Tests/KilnTests/DocCRendererTests.swift
+++ b/Tests/KilnTests/DocCRendererTests.swift
@@ -118,6 +118,32 @@ struct DocCRendererTests {
         #expect(!html.contains("<code>The Guide</code>"))
     }
 
+    @Test("Inline external-link references render as anchors, not plain text")
+    func rendersExternalLinkReference() throws {
+        let node = try decode("""
+        {
+          "schemaVersion": {"major": 0, "minor": 3, "patch": 0},
+          "identifier": {"url": "doc://T/documentation/T/X", "interfaceLanguage": "swift"},
+          "kind": "symbol",
+          "metadata": {"title": "X", "roleHeading": "Structure", "symbolKind": "struct"},
+          "abstract": [{"type": "text", "text": "See the "},
+                       {"type": "reference", "identifier": "https://api.vapor.codes", "isActive": true},
+                       {"type": "text", "text": " for details."}],
+          "primaryContentSections": [],
+          "references": {
+            "https://api.vapor.codes": {"type": "link", "title": "Vapor API docs",
+               "url": "https://api.vapor.codes"}
+          }
+        }
+        """)
+
+        let html = DocCRenderer().render(node).contentHTML
+        // The external link is a real anchor to its absolute URL (not run through
+        // the path mapper, which is for archive-relative DocC paths), with the
+        // reference's title as the visible text.
+        #expect(html.contains("<a href=\"https://api.vapor.codes\">Vapor API docs</a>"))
+    }
+
     @Test("Discussion asides, code listings, and tables render")
     func rendersRichBlocks() throws {
         let node = try decode("""


### PR DESCRIPTION
Fixes an issue where external link weren't rendered. Adds an example to the DocC site so we can ensure it works
