### PR TITLE
Give the selected search suggestion its own, louder style

### DIFF
--- a/Sources/Kiln/Resources/DefaultTheme/css/theme.css
+++ b/Sources/Kiln/Resources/DefaultTheme/css/theme.css
@@ -396,8 +396,43 @@ details.admonition > summary.admonition-title::-webkit-details-marker { display:
     padding: 8px;
     z-index: 100;
 }
-.kiln-search-result { display: block; padding: 10px 12px; border-radius: 8px; color: var(--text); }
-.kiln-search-result:hover, .kiln-search-result.kiln-active { background: var(--surface); text-decoration: none; }
+.kiln-search-result { display: block; position: relative; padding: 10px 12px; border-radius: 8px; color: var(--text); }
+.kiln-search-result:hover { background: var(--surface); text-decoration: none; }
+
+/* The keyboard selection has to outrank hover rather than match it. Sharing
+   one background gave it two problems: --surface sits a couple of percent
+   off --bg, so the selection was nearly invisible on its own, and with the
+   pointer anywhere over the list two rows lit up identically with no telling
+   which one Return would open.
+
+   Hence a treatment hover does not get — an accent-tinted fill and a bar down
+   the leading edge. The bar is the part that survives a high-contrast palette
+   and a reader who cannot separate the two fills by hue: it is a shape, not a
+   tint. */
+.kiln-search-result.kiln-active {
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    text-decoration: none;
+}
+.kiln-search-result.kiln-active::before {
+    content: "";
+    position: absolute;
+    inset-block: 4px;
+    inset-inline-start: 0;
+    width: 3px;
+    border-radius: 999px;
+    background: var(--accent);
+}
+.kiln-search-result.kiln-active .kiln-search-result-title { color: var(--accent); }
+/* --muted loses too much against the tinted fill; on the selected row the
+   context line reads as body text. */
+.kiln-search-result.kiln-active .kiln-search-result-context { color: var(--text); }
+/* The <mark> and the badge are already accent tints, and tint-on-tint goes
+   muddy — push both enough to stay distinct inside the fill. */
+.kiln-search-result.kiln-active mark { background: color-mix(in srgb, var(--accent) 45%, transparent); }
+.kiln-search-result.kiln-active .kiln-search-result-badge {
+    background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 .kiln-search-result-title { font-weight: 600; display: block; }
 /* Kind pill on a result (e.g. a DocC module landing page). */
 .kiln-search-result-badge {

--- a/Sources/Kiln/Resources/DefaultTheme/js/search.js
+++ b/Sources/Kiln/Resources/DefaultTheme/js/search.js
@@ -235,7 +235,9 @@
     }
 
     // Highlight the result at `index`, wrapping past either end, and keep it in
-    // view. Drives the `.kiln-active` style the theme already defines for hover.
+    // view. Drives the theme's `.kiln-active` style, which is deliberately
+    // louder than hover: with a pointer resting over the list, two rows styled
+    // alike leave no way to tell which one Return will open.
     function setActive(index) {
         var links = resultLinks();
         if (!links.length) { activeIndex = -1; input.removeAttribute("aria-activedescendant"); return; }


### PR DESCRIPTION
`.kiln-search-result:hover` and `.kiln-search-result.kiln-active` share one declaration, so the row the arrow keys have selected and the row the pointer happens to be over look identical.

Two things go wrong with that:

- The selection is nearly invisible on its own. `--surface` sits a couple of percent off `--bg` in both palettes — the right weight for a hover hint, far too quiet for "this is what Return opens".
- When the pointer *is* over the list — which it is, because the panel opens under the cursor as you type — two rows light up the same way and nothing distinguishes the keyboard's choice.

So selection now gets a treatment hover does not: an accent-tinted fill, an accent title, a body-weight context line, and a bar down the leading edge.

The bar is the load-bearing part. A tint difference is the first thing to go in a high-contrast palette, under a custom `--accent` close to `--surface`, or for a reader who can't separate two fills by hue; a 3px shape at the edge of the row survives all three. It uses `inset-inline-start`, so it follows writing direction.

The `<mark>` and the kind badge inside a selected row are themselves accent tints, and tint-on-tint reads as mud, so both are pushed up enough to stay legible against the fill.

Also updates one comment in `search.js` that described `.kiln-active` as "the style the theme already defines for hover" — accurate before this change, and precisely the assumption that would invite someone to re-merge the two rules.

**No new platform requirement:** `color-mix()` and the logical inset properties were already in use in this file.

**Testing:** `swift test` passes (237 tests); no test asserts on these rules. Verified in both palettes on a real site — light fill resolves to `srgb(0.869 0.910 0.987)` on white, dark to `srgb(0.079 0.126 0.217)` on `#0f1115`, bar `rgb(47 111 235)` at 3px in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)